### PR TITLE
Modernize Tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,22 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-replace": "^3.1.0",
+    "@tsconfig/svelte": "^3.0.0",
+    "netlify-cli": "^9.6.5",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
     "svelte": "^3.0.0",
-    "svelte-watch-resize": "^1.0.3"
+    "svelte-check": "^2.9.2",
+    "svelte-grid": "^5.1.1",
+    "svelte-preprocess": "^4.10.7",
+    "svelte-watch-resize": "^1.0.3",
+    "typescript": "^4.8.4"
   },
   "dependencies": {
+    "@rollup/plugin-typescript": "^9.0.1",
     "google-spreadsheet": "^3.2.0",
     "mapbox-gl": "^2.7.0",
     "netlify-cli": "^12.0.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-livereload": "^2.0.0",
-    "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
     "svelte": "^3.0.0",
     "svelte-check": "^2.9.2",
@@ -31,6 +30,8 @@
     "google-spreadsheet": "^3.2.0",
     "mapbox-gl": "^2.7.0",
     "netlify-cli": "^12.0.7",
+    "rollup-plugin-hot": "^0.1.1",
+    "rollup-plugin-svelte-hot": "1.0.0-8",
     "sirv-cli": "^2.0.0",
     "three": "^0.145.0",
     "underscore": "^1.13.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 import css from 'rollup-plugin-css-only';
+import autoPreprocess from 'svelte-preprocess';
+import typescript from '@rollup/plugin-typescript';
 
 import replace from '@rollup/plugin-replace';
 
@@ -48,6 +50,7 @@ export default {
 		}),
 
 		svelte({
+			preprocess: autoPreprocess(),
 			compilerOptions: {
 				// enable run-time checks when not in production
 				dev: !production
@@ -67,6 +70,7 @@ export default {
 			dedupe: ['svelte']
 		}),
 		commonjs(),
+		typescript({ sourceMap: !production }),
 
 		// In dev mode, call `npm run start` once
 		// the bundle has been generated

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { onMount } from "svelte";
   import { throttle } from "underscore";
   import LocalMediaInput from "./components/LocalMediaInput.svelte";

--- a/src/components/LocalMediaInput.svelte
+++ b/src/components/LocalMediaInput.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import { local_file_store } from "../stores/store";
 
     let input_container, media_input;

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { missing_component } from "svelte/internal";
   import {
     media_store_filtered,

--- a/src/components/modules/FilterPanel.svelte
+++ b/src/components/modules/FilterPanel.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import { ui_store, filter_toggles } from "../../stores/store";
 
     function onCheckboxChange(event, filter, possible_value) {

--- a/src/components/modules/Map.svelte
+++ b/src/components/modules/Map.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { Map, Marker, controls } from "@beyonk/svelte-mapbox";
   import { throttle } from "underscore";
   import { watchResize } from "svelte-watch-resize";

--- a/src/components/modules/Media.svelte
+++ b/src/components/modules/Media.svelte
@@ -1,6 +1,6 @@
-<script>
-  import { ui_store, media_store } from "../../stores/store";
-  import Module from "./Module.svelte";
+<script lang="ts">
+ import { ui_store, media_store } from "../../stores/store";
+ import Module from "./Module.svelte";
 </script>
 
 <div class="media">

--- a/src/components/modules/MediumVideo.svelte
+++ b/src/components/modules/MediumVideo.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { local_file_store, platform_config_store } from "../../stores/store";
   export let medium;
 

--- a/src/components/modules/Module.svelte
+++ b/src/components/modules/Module.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { ui_store } from "../../stores/store";
   import TimelineThree from "./TimelineThree.svelte";
   import Map from "./Map.svelte";

--- a/src/components/modules/Modules.svelte
+++ b/src/components/modules/Modules.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import Module from "./Module.svelte";
   import Media from "./Media.svelte";
   import { ui_store } from "../../stores/store";

--- a/src/components/modules/TimelineThree.svelte
+++ b/src/components/modules/TimelineThree.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { onMount } from "svelte";
   import { throttle } from "underscore";
 

--- a/src/components/topbar/About.svelte
+++ b/src/components/topbar/About.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     let about_in_view = false;
 </script>
 

--- a/src/components/topbar/FilterButton.svelte
+++ b/src/components/topbar/FilterButton.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import { ui_store } from "../../stores/store";
 </script>
 

--- a/src/components/topbar/Finder.svelte
+++ b/src/components/topbar/Finder.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import { ui_store, media_store } from "../../stores/store";
     let input;
     let input_focused = false;

--- a/src/components/topbar/ModuleTools.svelte
+++ b/src/components/topbar/ModuleTools.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import { ui_store } from "../../stores/store";
 
     function toggle_module(module) {

--- a/src/components/topbar/Topbar.svelte
+++ b/src/components/topbar/Topbar.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import FilterButton from "./FilterButton.svelte";
     import Finder from "./Finder.svelte";
     import ModuleTools from "./ModuleTools.svelte";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "include": ["src", "src/node_modules"],
+  "exclude": ["node_modules/*", "__sapper__/*", "public/*"],
+}


### PR DESCRIPTION
Hello, we're working on some patches for codec, but found the dev workflow a bit tedious.

this PR implements 2 things:
 - enable typescript for all svelte files to catch errors earlier
 - enable Hot Module Reloading to be able to see live updates of components without reloading the whole app on every change.

cheers,